### PR TITLE
fix #14, fix #12

### DIFF
--- a/dwmExec.cc
+++ b/dwmExec.cc
@@ -233,9 +233,6 @@ namespace micaElectron
     napi_value *argv = new napi_value[argc];
     napi_get_cb_info(env, args, &argc, argv, nullptr, nullptr);
 
-    if (!isWin11())
-      napi_throw_error(env, nullptr, "Mica-Electron work only on Windows 11.");
-
     else if (argc < 1)
       napi_throw_error(env, nullptr, "HWND argument missing.");
 


### PR DESCRIPTION
`executeUser32` is used in the code for Windows 10 (e.g. `setAcrylic`), so it **should** not contain the Windows 11 check.